### PR TITLE
Add dependency to consoleprinter package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,4 @@ setup(name='arguments',
           "Operating System :: POSIX",
           "Topic :: Software Development :: Libraries :: Python Modules",
           "Topic :: System",
-      ], requires=['future', 'ujson', 'sh'])
+      ], requires=['consoleprinter', 'future', 'ujson', 'sh'])


### PR DESCRIPTION
When first installing it for use in [dermesser/photosync](https://github.com/dermesser/photosync), this dependency had to be installed manually.